### PR TITLE
Move angularHtmlify before angularTemplatecache

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -62,11 +62,11 @@ gulp.task('scripts', function() {
 gulp.task('partials', function() {
   return gulp.src('app/views/**/*.html')
     .pipe($.minifyHtml(minifyHtmlOptions))
+    .pipe($.angularHtmlify())
     .pipe($.angularTemplatecache({
       root: 'views',
       standalone: true
     }))
-    .pipe($.angularHtmlify())
     .pipe(gulp.dest('.tmp'))
     .pipe($.size());
 });


### PR DESCRIPTION
We have some problems when compile angularTemplatecache before angularHtmlify
